### PR TITLE
Use large executor for building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     working_directory: ~/aus-ddr-poc
     docker:
       - image: cimg/node:15.6.0
-    resource_class: medium
+    resource_class: large
     steps:
       - attach_workspace:
           at: ~/


### PR DESCRIPTION
Seems parcel2 has a bug resulting in high memory usage. Temporarily using a larger executor for the build.